### PR TITLE
Removed deprecated calls and selectors

### DIFF
--- a/keymaps/tag.cson
+++ b/keymaps/tag.cson
@@ -7,5 +7,5 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.workspace':
+'atom-workspace':
   'cmd-alt-.': 'tag:close-tag'

--- a/lib/tag.js
+++ b/lib/tag.js
@@ -14,7 +14,7 @@ module.exports = {
         });
     });
 
-    return atom.workspaceView.command("tag:close-tag", (function(_this) {
+    return atom.commands.add("atom-workspace", "tag:close-tag", (function(_this) {
       return function() {
         return _this.closeTag();
       };

--- a/lib/tag.js
+++ b/lib/tag.js
@@ -8,8 +8,8 @@ module.exports = {
   activate: function(state) {
     var _this = this;
 
-    atom.workspaceView.eachEditorView(function(editorView) {
-        editorView.editor.buffer.on('changed', function(e) {
+    atom.workspace.observeTextEditors(function(editor) {
+        editor.buffer.on('changed', function(e) {
           _this.bufferChanged(e);
         });
     });


### PR DESCRIPTION
Atom deprecated all uses of `workspaceView` and throws up an annoying warning for everyone using the package.  Instead of creating an issue I just made the changes.  You'll have to do an `apm publish patch` to get them out in the wild.