### PR TITLE
Test against grammar scope instead of name for universal application.

### DIFF
--- a/lib/tag.js
+++ b/lib/tag.js
@@ -39,11 +39,8 @@ module.exports = {
       return;
     }
 
-    var grammar = editor.getGrammar().name;
-    if (
-      grammar.length == 0 ||
-      (grammar.indexOf('HTML') < 0 && grammar.indexOf('XML') < 0 && grammar.indexOf('Handlebars') < 0)
-    ) {
+    var grammar = editor.getGrammar();
+    if (!/text\.(?:html|xml)/.test(grammar.scopeName)) {
       return;
     }
 


### PR DESCRIPTION
This eliminates the need to test for "Handlebars" or any other html templating grammar.
Should also fix #18.